### PR TITLE
chore(deps): update hashicorp/terraform to 1.9.1

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,7 +27,7 @@ jobs:
         name: Setup Terraform
         uses: hashicorp/setup-terraform@v3
         with:
-          terraform_version: 1.7.3
+          terraform_version: 1.9.1
       -
         name: terraform fmt
         run: terraform fmt -recursive


### PR DESCRIPTION
Update [hashicorp/terraform](https://github.com/hashicorp/terraform) to [1.9.1](https://github.com/hashicorp/terraform/releases/tag/v1.9.1)
This PR is auto generated by [depup workflow](https://github.com/nasa9084/infrastructure/actions?query=workflow%3Adepup).