### PR TITLE
chore(deps): update terraform-linters/tflint to 0.54.0

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -50,5 +50,5 @@ jobs:
         with:
           github_token: ${{ secrets.github_token }}
           fail_on_error: true
-          tflint_version: v0.50.2
+          tflint_version: v0.54.0
           flags: "--recursive"


### PR DESCRIPTION
Update [terraform-linters/tflint](https://github.com/terraform-linters/tflint) to [0.54.0](https://github.com/terraform-linters/tflint/releases/tag/v0.54.0)
This PR is auto generated by [depup workflow](https://github.com/nasa9084/infrastructure/actions?query=workflow%3Adepup).