### PR TITLE
chore(deps): update terraform-linters/tflint to 0.55.1

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -50,5 +50,5 @@ jobs:
         with:
           github_token: ${{ secrets.github_token }}
           fail_on_error: true
-          tflint_version: v0.55.0
+          tflint_version: v0.55.1
           flags: "--recursive"


### PR DESCRIPTION
Update [terraform-linters/tflint](https://github.com/terraform-linters/tflint) to [0.55.1](https://github.com/terraform-linters/tflint/releases/tag/v0.55.1)
This PR is auto generated by [depup workflow](https://github.com/nasa9084/infrastructure/actions?query=workflow%3Adepup).