### PR TITLE
chore(deps): update hashicorp/setup-terraform to 3.1.2

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,7 +27,7 @@ jobs:
         name: Setup Terraform
         uses: hashicorp/setup-terraform@v3
         with:
-          terraform_version: 1.10.5
+          terraform_version: 3.1.2
       -
         name: terraform fmt
         run: terraform fmt -recursive


### PR DESCRIPTION
Update [hashicorp/setup-terraform](https://github.com/hashicorp/setup-terraform) to [3.1.2](https://github.com/hashicorp/setup-terraform/releases/tag/v3.1.2)
This PR is auto generated by [depup workflow](https://github.com/nasa9084/infrastructure/actions?query=workflow%3Adepup).