### PR TITLE
chore(deps): update hashicorp/terraform to 1.12.2

### DIFF
--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -49,7 +49,7 @@ jobs:
         name: Setup Terraform
         uses: hashicorp/setup-terraform@v3
         with:
-          terraform_version: 1.7.3
+          terraform_version: 1.12.2
           cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
       -
         name: Setup tfcmt


### PR DESCRIPTION
Update [hashicorp/terraform](https://github.com/hashicorp/terraform) to [1.12.2](https://github.com/hashicorp/terraform/releases/tag/v1.12.2)
This PR is auto generated by [depup workflow](https://github.com/nasa9084/infrastructure/actions?query=workflow%3Adepup).